### PR TITLE
shorten slots per epoch

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -10,3 +10,6 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+
+[test_validator.validator]
+slots_per_epoch = "32"


### PR DESCRIPTION
im not sure if there's a way to warp slots in anchor: https://github.com/project-serum/anchor/issues/657, but doing this should shorten an epoch to ~16 seconds so that we can just sleep that amount of time in tests to wait for the epoch boundary

32 is the min slots per epoch btw